### PR TITLE
Update schedule_fetch_chat.yml

### DIFF
--- a/.github/workflows/schedule_fetch_chat.yml
+++ b/.github/workflows/schedule_fetch_chat.yml
@@ -30,3 +30,9 @@ jobs:
 
       - name: チャットデータ取得スクリプトの実行
         run: python python/fetch_chat_data.py
+    
+      - name: Update yt-dlp YouTube cookies
+        uses: AnimMouse/setup-yt-dlp/cookies/update@v3
+        with:
+          cookies_secret_name: YOUTUBE_COOKIES
+          token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/schedule_fetch_chat.yml
+++ b/.github/workflows/schedule_fetch_chat.yml
@@ -23,10 +23,15 @@ jobs:
       - name: 必要なパッケージのインストール
         run: |
           python -m pip install --upgrade pip
-          pip install yt-dlp requests
-          
-      - name: cookies.txt を取得
-        run: echo "${{ secrets.YOUTUBE_COOKIES }}" > cookies.txt
+          pip install requests
+    
+      - name: Setup yt-dlp
+        uses: AnimMouse/setup-yt-dlp@v3
+        
+      - name: Setup yt-dlp YouTube cookies
+        uses: AnimMouse/setup-yt-dlp/cookies@v3
+        with:
+          cookies: ${{ secrets.YOUTUBE_COOKIES }}
 
       - name: チャットデータ取得スクリプトの実行
         run: python python/fetch_chat_data.py

--- a/python/fetch_chat_data.py
+++ b/python/fetch_chat_data.py
@@ -37,7 +37,6 @@ def fetch_and_post_chat_data(video_ids):
                 "--sub-lang", "live_chat",
                 "--skip-download",
                 "--output", f"{output_dir}/{video_id}.%(ext)s",
-                "--cookies", "cookies.txt",
                 video_url
             ], check=True)
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Update cookies
Cookies have expiration, which means it has to be refreshed, or else it will expire and it will not work anymore. To prevent expiration, yt-dlp automatically refreshes the cookies as needed. To update those cookies in GitHub secrets, use the AnimMouse/setup-yt-dlp/cookies/update@v3 action to update those cookies.

This requires a fine-grained personal access token that has read and write access to the secrets scope in the current repository to update the secret as the default GITHUB_TOKEN does not have access to the secrets scope.