### PR TITLE
Integrate Claude API for bot replies

### DIFF
--- a/app/chat-display/index.tsx
+++ b/app/chat-display/index.tsx
@@ -74,10 +74,10 @@ export default function ChatDisplay({
     }
   }, [pairQueue, currentPair, processQueue]);
 
-  const handleSendMessage = useCallback(() => {
+  const handleSendMessage = useCallback(async () => {
     if (!inputText.trim()) return;
 
-    const newPair = createChatPair(inputText.trim());
+    const newPair = await createChatPair(inputText.trim());
     setPairQueue((prevQueue) => [...prevQueue, newPair]);
     setInputText("");
 
@@ -137,12 +137,12 @@ export default function ChatDisplay({
           pageToken = chatData.nextPageToken;
           const chats = chatData.items || [];
           if (chats.length > 0) {
-            setPairQueue((prev) => [
-              ...prev,
-              ...chats.map((c: any) =>
+            const newPairs = await Promise.all(
+              chats.map((c: any) =>
                 createChatPair(c.snippet?.displayMessage || "")
-              ),
-            ]);
+              )
+            );
+            setPairQueue((prev) => [...prev, ...newPairs]);
           }
           const waitMs = chatData.pollingIntervalMillis || 5000;
           await sleep(waitMs);

--- a/app/chat-display/utils.ts
+++ b/app/chat-display/utils.ts
@@ -1,33 +1,18 @@
-import { ChatMessage, ChatPair } from './types';
+import { ChatMessage, ChatPair } from "./types";
+import { generateChatBotMessages } from "../../lib/claude";
 
 // 簡単なボット返信生成関数
-export const generateBotReply = (userMessage: string): string => {
-  const replies = [
-    'それは興味深いですね！',
-    'なるほど、よく分かります。',
-    'そうですね、私もそう思います。',
-    'もう少し詳しく教えてください。',
-    'とても良い質問ですね。',
-    'その通りです！',
-    '面白い視点ですね。',
-    '確かにそうですね。',
-    'それについてもっと知りたいです。',
-    '素晴らしい考えです！',
-  ];
-
-  // メッセージの長さや内容に基づいて返信を選択
-  if (userMessage.includes('？') || userMessage.includes('?')) {
-    return 'それは良い質問ですね。考えてみましょう。';
+export const generateBotReply = async (userMessage: string): Promise<string> => {
+  try {
+    const res = await generateChatBotMessages(userMessage);
+    return res.recieveMessages[0] ?? "";
+  } catch (e) {
+    console.error("generateBotReply error", e);
+    return "申し訳ありません、エラーが発生しました。";
   }
-  
-  if (userMessage.length > 20) {
-    return '詳しく説明していただき、ありがとうございます。';
-  }
-
-  return replies[Math.floor(Math.random() * replies.length)];
 };
 
-export const createChatPair = (userText: string): ChatPair => {
+export const createChatPair = async (userText: string): Promise<ChatPair> => {
   const timestamp = Date.now();
   const userMessage: ChatMessage = {
     id: `user_${timestamp}`,
@@ -38,7 +23,7 @@ export const createChatPair = (userText: string): ChatPair => {
 
   const botReply: ChatMessage = {
     id: `bot_${timestamp}`,
-    text: generateBotReply(userText),
+    text: await generateBotReply(userText),
     timestamp: timestamp + 1000, // 1秒後の返信
     type: 'bot',
   };

--- a/lib/claude.ts
+++ b/lib/claude.ts
@@ -1,0 +1,124 @@
+// Claude API のレスポンス型
+export interface MessageResponse {
+  id: string;
+  model: string;
+  role: "assistant";
+  type: "message";
+  content: {
+    type: "text";
+    text: string;
+    citations:
+      | {
+          type: "char_location";
+          cited_text: string;
+          document_index: number; // x > 0
+          document_title: string | null;
+          start_char_index: number; // x > 0
+          end_char_index: number;
+        }[]
+      | null;
+  }[];
+  stop_reason: "end_turn" | "max_tokens" | "stop_sequence" | "tool_use";
+  stop_sequence: string | null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
+
+// スポットガイド生成レスポンス型
+export type ChatBotMessagesResponse = {
+  recieveMessages: string[];
+};
+
+export const generateChatBotMessages = async (
+  sendMessages: string
+): Promise<
+  ChatBotMessagesResponse & {
+    familyId: string;
+    variantId: string;
+    promptText: string;
+    generatedText: string;
+    promptInput: Record<string, any>;
+    llmModel: string;
+    temperature: number;
+  }
+> => {
+  const llmModel = "claude-3-haiku-20240307";
+  const temperature = 0.7;
+
+  // 🎨 実際のプロンプト文を構築（JSON形式でレスポンスを要求）
+  const prompt = `
+Input ${sendMessages}
+
+Use the following JSON format for output.
+{
+  recieveMessages: string;
+}[]`.trim();
+
+  const requestPayload = {
+    model: llmModel,
+    max_tokens: 512,
+    temperature,
+    messages: [
+      {
+        role: "user" as const,
+        content: prompt,
+      },
+    ],
+  };
+
+  const response: MessageResponse = await fetch(
+    "https://api.anthropic.com/v1/messages",
+    {
+      method: "POST",
+      headers: {
+        "x-api-key": process.env.EXPO_PUBLIC_CLAUDE_API_KEY ?? "",
+        "anthropic-version": "2023-06-01",
+        "anthropic-dangerous-direct-browser-access": "true",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestPayload),
+    }
+  ).then((res) => res.json());
+
+  if (response.stop_reason && response.stop_reason !== "end_turn") {
+    throw new Error(
+      `Claude API failed: Unexpected stop_reason - ${response.stop_reason}`
+    );
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(response.content[0]?.text || "{}");
+  } catch (e) {
+    throw new Error(
+      `Claude API failed: Invalid JSON response - ${(e as Error).message}`
+    );
+  }
+
+  // 簡易的なバリデーション
+  const recieveMessages: string[] = Array.isArray(parsedJson)
+    ? (parsedJson as any[])
+        .map((item) => (typeof item.recieveMessages === "string" ? item.recieveMessages : null))
+        .filter((m): m is string => m !== null)
+    : [];
+
+  const validatedResponse: ChatBotMessagesResponse = {
+    recieveMessages,
+  };
+
+  // 📤 JSONとしてレスポンスをパースし返却
+  return {
+    ...validatedResponse,
+    familyId: response.id,
+    variantId: response.model,
+    promptText: prompt,
+    generatedText: response.content[0]?.text ?? "",
+    promptInput: requestPayload,
+    llmModel,
+    temperature,
+  };
+};


### PR DESCRIPTION
## Summary
- add new Claude API wrapper in `lib/claude.ts`
- switch bot reply logic to use Claude
- update chat pair creation and message handling for async replies

## Testing
- `npm run lint` *(fails: `expo: not found`)*
- `npm run typecheck` *(fails: cannot find dependencies)*
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685347849410832bb49742237b8c87ce