### PR TITLE
Add VideoCanvasRenderer and replace inline <video> with canvas-based renderer in AlertBox

### DIFF
--- a/app/alertbox/components/VideoCanvasRenderer.tsx
+++ b/app/alertbox/components/VideoCanvasRenderer.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useRef } from "react";
+
+type VideoCanvasRendererProps = {
+  src: string;
+  style: React.CSSProperties;
+  onError: (reason: Record<string, unknown>) => void;
+  onLoadStart: () => void;
+  onLoadedMetadata: (meta: {
+    duration: number;
+    readyState: number;
+    networkState: number;
+  }) => void;
+  onCanPlay: (meta: { readyState: number; networkState: number }) => void;
+  onPlaying: () => void;
+  onEnded: (meta: { duration: number }) => void;
+};
+
+export function VideoCanvasRenderer({
+  src,
+  style,
+  onError,
+  onLoadStart,
+  onLoadedMetadata,
+  onCanPlay,
+  onPlaying,
+  onEnded,
+}: VideoCanvasRendererProps) {
+  const hiddenVideoRef = useRef<HTMLVideoElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const video = hiddenVideoRef.current;
+    const canvas = canvasRef.current;
+
+    if (!video || !canvas) return;
+
+    const context = canvas.getContext("2d");
+    if (!context) {
+      onError({ reason: "missingCanvasContext" });
+      return;
+    }
+
+    let ended = false;
+    let hasRenderedFrame = false;
+    let rafId = 0;
+    let rvfcId = 0;
+
+    const syncCanvasSize = () => {
+      const width = video.videoWidth || canvas.clientWidth || 1;
+      const height = video.videoHeight || canvas.clientHeight || 1;
+
+      if (canvas.width !== width) canvas.width = width;
+      if (canvas.height !== height) canvas.height = height;
+    };
+
+    const drawFrame = () => {
+      if (video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
+
+      syncCanvasSize();
+      context.drawImage(video, 0, 0, canvas.width, canvas.height);
+      hasRenderedFrame = true;
+    };
+
+    const startRafLoop = () => {
+      const loop = () => {
+        drawFrame();
+        if (!ended) {
+          rafId = window.requestAnimationFrame(loop);
+        }
+      };
+
+      rafId = window.requestAnimationFrame(loop);
+    };
+
+    const startRvfcLoop = () => {
+      if (!video.requestVideoFrameCallback) {
+        startRafLoop();
+        return;
+      }
+
+      const loop = () => {
+        drawFrame();
+        if (!ended) {
+          rvfcId = video.requestVideoFrameCallback(loop);
+        }
+      };
+
+      rvfcId = video.requestVideoFrameCallback(loop);
+    };
+
+    const renderTimeoutId = window.setTimeout(() => {
+      if (!hasRenderedFrame) {
+        onError({ reason: "renderStartTimeout", readyState: video.readyState });
+      }
+    }, 3000);
+
+    const handleLoadedMetadata = () => {
+      syncCanvasSize();
+      onLoadedMetadata({
+        duration: video.duration,
+        readyState: video.readyState,
+        networkState: video.networkState,
+      });
+    };
+
+    const handleCanPlay = () => {
+      onCanPlay({
+        readyState: video.readyState,
+        networkState: video.networkState,
+      });
+    };
+
+    const handlePlaying = () => {
+      onPlaying();
+      startRvfcLoop();
+    };
+
+    const handleEnded = () => {
+      ended = true;
+      drawFrame();
+      onEnded({ duration: video.duration });
+    };
+
+    const handleError = () => {
+      ended = true;
+      const mediaError = video.error;
+      onError({
+        reason: "videoError",
+        code: mediaError?.code,
+        message: mediaError?.message,
+        readyState: video.readyState,
+        networkState: video.networkState,
+      });
+    };
+
+    onLoadStart();
+
+    video.addEventListener("loadedmetadata", handleLoadedMetadata);
+    video.addEventListener("canplay", handleCanPlay);
+    video.addEventListener("playing", handlePlaying);
+    video.addEventListener("ended", handleEnded);
+    video.addEventListener("error", handleError);
+
+    const playPromise = video.play();
+    if (playPromise && typeof playPromise.catch === "function") {
+      playPromise.catch((error) => {
+        ended = true;
+        onError({
+          reason: "playRejected",
+          message: error instanceof Error ? error.message : String(error),
+          name:
+            typeof error === "object" && error && "name" in error
+              ? String((error as { name?: string }).name)
+              : undefined,
+        });
+      });
+    }
+
+    return () => {
+      ended = true;
+      window.clearTimeout(renderTimeoutId);
+      window.cancelAnimationFrame(rafId);
+
+      if (video.cancelVideoFrameCallback && rvfcId) {
+        video.cancelVideoFrameCallback(rvfcId);
+      }
+
+      video.pause();
+      video.removeEventListener("loadedmetadata", handleLoadedMetadata);
+      video.removeEventListener("canplay", handleCanPlay);
+      video.removeEventListener("playing", handlePlaying);
+      video.removeEventListener("ended", handleEnded);
+      video.removeEventListener("error", handleError);
+    };
+  }, [onCanPlay, onEnded, onError, onLoadStart, onLoadedMetadata, onPlaying, src]);
+
+  return (
+    <>
+      <video
+        ref={hiddenVideoRef}
+        autoPlay
+        controls={false}
+        loop={false}
+        muted
+        playsInline
+        preload="auto"
+        src={src}
+        style={{ display: "none" }}
+      />
+      <canvas ref={canvasRef} style={style} />
+    </>
+  );
+}

--- a/app/alertbox/index.tsx
+++ b/app/alertbox/index.tsx
@@ -35,6 +35,7 @@ import { speak } from "./tts.utils";
 import { getMainTextStyle, getSubMessageStyle } from "./styles.utils";
 import { DoneruConnector, YouTubeConnector } from "./connectors";
 import { getTable, getById, insert, getDoneruAmount } from "./api.utils";
+import { VideoCanvasRenderer } from "./components/VideoCanvasRenderer";
 
 // 受け付け可能な通知タイプのリスト（ガードに利用）
 const NOTIFICATION_TYPES = [
@@ -99,8 +100,6 @@ export default function AlertBox() {
 
   // セッション識別子（ログ相関用）
   const sessionId = useRef(new Date().getTime());
-
-  const videoRef = useRef<HTMLVideoElement | null>(null);
 
   // エラーメッセージ
   const [error, setError] = useState<string | null>(null);
@@ -526,37 +525,6 @@ export default function AlertBox() {
     setDisplaySource({ type: "image", url: fallbackImageUrl });
   }, [iconUrl, imageUrl, notification]);
 
-  // play() の失敗を拾う useEffect
-  useEffect(() => {
-    if (Platform.OS !== "web") return;
-    if (displaySource.type !== "video" || !displaySource.url) return;
-    if (!videoRef.current) return;
-
-    const el = videoRef.current;
-
-    sendLog("AlertBox", sessionId, "videoPlayAttempt", {
-      url: displaySource.url,
-      readyState: el.readyState,
-      networkState: el.networkState,
-    });
-
-    const playPromise = el.play();
-
-    if (playPromise && typeof playPromise.catch === "function") {
-      playPromise.catch((error) => {
-        sendLog("AlertBox", sessionId, "videoPlayRejected", {
-          url: displaySource.url,
-          message: error instanceof Error ? error.message : String(error),
-          name:
-            typeof error === "object" && error && "name" in error
-              ? String((error as { name?: string }).name)
-              : undefined,
-        });
-        fallbackToImageSource();
-      });
-    }
-  }, [displaySource, fallbackToImageSource]);
-
   // 金額に比例したエフェクト回数（花火/雨）を算出
   const effectCounts = useMemo(
     () =>
@@ -590,14 +558,7 @@ export default function AlertBox() {
               notification.type === "superchat") && (
               <View style={styles.alertContainer}>
                 {displaySource.type === "video" && displaySource.url ? (
-                  <video
-                    ref={videoRef}
-                    autoPlay
-                    controls={false}
-                    loop={false}
-                    muted
-                    playsInline
-                    preload="auto"
+                  <VideoCanvasRenderer
                     src={displaySource.url}
                     style={{ ...styles.image }}
                     onLoadStart={() =>
@@ -605,19 +566,16 @@ export default function AlertBox() {
                         url: displaySource.url,
                       })
                     }
-                    onLoadedMetadata={(e) =>
+                    onLoadedMetadata={(meta) =>
                       sendLog("AlertBox", sessionId, "videoLoadedMetadata", {
                         url: displaySource.url,
-                        duration: e.currentTarget.duration,
-                        readyState: e.currentTarget.readyState,
-                        networkState: e.currentTarget.networkState,
+                        ...meta,
                       })
                     }
-                    onCanPlay={(e) =>
+                    onCanPlay={(meta) =>
                       sendLog("AlertBox", sessionId, "videoCanPlay", {
                         url: displaySource.url,
-                        readyState: e.currentTarget.readyState,
-                        networkState: e.currentTarget.networkState,
+                        ...meta,
                       })
                     }
                     onPlaying={() =>
@@ -625,27 +583,16 @@ export default function AlertBox() {
                         url: displaySource.url,
                       })
                     }
-                    onEnded={(e) => {
-                      const v = e.currentTarget;
-                      v.pause();
-
-                      if (Number.isFinite(v.duration) && v.duration > 0) {
-                        v.currentTime = Math.max(v.duration - 0.05, 0);
-                      }
-
+                    onEnded={(meta) =>
                       sendLog("AlertBox", sessionId, "videoEnded", {
                         url: displaySource.url,
-                        duration: v.duration,
-                      });
-                    }}
-                    onError={(e) => {
-                      const mediaError = e.currentTarget.error;
+                        ...meta,
+                      })
+                    }
+                    onError={(meta) => {
                       sendLog("AlertBox", sessionId, "videoError", {
                         url: displaySource.url,
-                        code: mediaError?.code,
-                        message: mediaError?.message,
-                        readyState: e.currentTarget.readyState,
-                        networkState: e.currentTarget.networkState,
+                        ...meta,
                       });
                       fallbackToImageSource();
                     }}


### PR DESCRIPTION
### Motivation

- Provide a more resilient video rendering path for the alert box by drawing video frames to a canvas so playback/render failures and frame timing can be handled and reported uniformly.

### Description

- Add `VideoCanvasRenderer` component that renders a hidden `<video>` and a `<canvas>` and copies frames using `requestVideoFrameCallback` or `requestAnimationFrame`, with canvas size syncing and a render-start timeout.
- Emit structured callbacks from the renderer (`onLoadStart`, `onLoadedMetadata`, `onCanPlay`, `onPlaying`, `onEnded`, `onError`) carrying simple meta objects instead of relying on DOM event objects.
- Replace the inline `<video>` usage in `app/alertbox/index.tsx` with `VideoCanvasRenderer` and remove the separate `videoRef` play-catch effect, wiring existing logging and fallback behavior to the new component's callbacks.
- Improve error reporting from play rejection, missing canvas context, and video errors and fall back to image source on renderer errors.

### Testing

- Ran TypeScript type checking (`tsc --noEmit`) and linter checks locally and they completed successfully.
- No new automated unit tests were added for the renderer in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5db769204832b8024137a8d06253d)