### PR TITLE
Replace ViewShot/MediaLibrary with html2canvas-based web export and add safe filename generation

### DIFF
--- a/app/ve-postit.tsx
+++ b/app/ve-postit.tsx
@@ -1,35 +1,53 @@
-import React, { useState } from "react";
-import { View, Text, TextInput, Button, Image, StyleSheet, Platform } from "react-native";
-import * as MediaLibrary from "expo-media-library";
-import ViewShot from "react-native-view-shot";
+import React, { useRef, useState } from "react";
+import { View, Text, TextInput, Button, StyleSheet, Platform, Alert } from "react-native";
+import html2canvas from "html2canvas";
+
+const WEB_CAPTURE_SCALE_FLOOR = 3;
+
+function buildFileName(title: string): string {
+  const safeTitle = title.trim().replace(/[^a-zA-Z0-9-_]+/g, "-").replace(/^-+|-+$/g, "");
+  const suffix = safeTitle.length > 0 ? `-${safeTitle}` : "";
+  return `${Date.now()}${suffix}.png`;
+}
 
 export default function App() {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  let viewShotRef = React.createRef<ViewShot>();
+  const postitRef = useRef<View>(null);
 
   const captureAndSave = async () => {
-    if (viewShotRef) {
-        viewShotRef.current?.capture?.().then(async (uri) => {
-          if (Platform.OS === "web") {
-            // Web 用のダウンロード処理
-            const link = document.createElement("a");
-            link.href = uri;
-            link.download = `${new Date().getTime()}-${title}.png`;
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-          } else {
-            // モバイル（iOS/Android）の場合、MediaLibrary を使用
-            const { status } = await MediaLibrary.requestPermissionsAsync();
-            if (status === "granted") {
-              await MediaLibrary.createAssetAsync(uri);
-              alert("Image saved to gallery!");
-            } else {
-              alert("Permission denied to save image.");
-            }
-          }
-        })
+    if (Platform.OS !== "web") {
+      Alert.alert("Unsupported", "This screen supports image export only on Web.");
+      return;
+    }
+
+    const node = postitRef.current as unknown as HTMLElement | null;
+    if (!node) {
+      Alert.alert("Error", "Capture target was not found.");
+      return;
+    }
+
+    try {
+      await document.fonts?.ready;
+
+      const scale = Math.max(window.devicePixelRatio || 1, WEB_CAPTURE_SCALE_FLOOR);
+      const canvas = await html2canvas(node, {
+        backgroundColor: "#faf7e0",
+        scale,
+        useCORS: true,
+        logging: false,
+      });
+
+      const dataUrl = canvas.toDataURL("image/png");
+      const link = document.createElement("a");
+      link.href = dataUrl;
+      link.download = buildFileName(title);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (error) {
+      console.error("captureAndSave failed", error);
+      Alert.alert("Export failed", "Could not generate an image. Please try again.");
     }
   };
 
@@ -48,12 +66,14 @@ export default function App() {
         onChangeText={setContent}
         multiline
       />
-      <ViewShot ref={viewShotRef} options={{ format: "png", quality: 1 }}>
-        <View style={styles.postit}>
-          <Text style={styles.postitTitle}>{title}</Text>
-          <Text style={styles.postitContent}>{content.split("\n").map((c,i) => (<Text key={i} style={styles.underline}>{c+"\n"}</Text>))}</Text>
-        </View>
-      </ViewShot>
+      <View ref={postitRef} style={styles.postit}>
+        <Text style={styles.postitTitle}>{title}</Text>
+        <Text style={styles.postitContent}>
+          {content.split("\n").map((c, i) => (
+            <Text key={i} style={styles.underline}>{`${c}\n`}</Text>
+          ))}
+        </Text>
+      </View>
       <Button title="Generate & Save" onPress={captureAndSave} />
     </View>
   );
@@ -99,8 +119,8 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     borderBottomColor: "#49372b",
     paddingBottom: 8,
-},
-postitContent: {
+  },
+  postitContent: {
     fontSize: 14,
     lineHeight: 21,
     textAlign: "left",


### PR DESCRIPTION
### Motivation

- Replace native-only screenshot flow with a reliable web capture path so the app can export post-it images in browsers. 
- Remove dependencies on `ViewShot` and `expo-media-library` for the web build and avoid attempting mobile-only save logic on browsers.
- Improve exported image quality and naming by waiting for web fonts, enforcing a minimum capture scale, and generating safe filenames.

### Description

- Added `html2canvas` usage and a `buildFileName` helper to capture the rendered `View` as a PNG and produce a sanitized filename for download.
- Replaced `ViewShot` with a `ref` (`postitRef`) to the view element and removed `expo-media-library` and `react-native-view-shot` imports and code paths. 
- Added platform guarding so `captureAndSave` only performs export on `Platform.OS === "web"`, waits for `document.fonts.ready`, applies a minimum `scale` (`WEB_CAPTURE_SCALE_FLOOR`), uses `canvas.toDataURL` to create a downloadable link, and shows `Alert` messages on errors or unsupported platforms.
- Cleaned up style formatting and preserved the visual layout and underline rendering of multiline content.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c627232370832b99f1034dcc7447c3)