### PR TITLE
nanitabeyo#780 月別・サマリーをサーバー取得に切り替え（重複カウントバグ修正）

### DIFF
--- a/app/daily_user_stats/components/StatPanel.tsx
+++ b/app/daily_user_stats/components/StatPanel.tsx
@@ -1,26 +1,26 @@
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import StatCard from './StatCard';
-import type { Aggregates } from '../lib/aggregate';
+import type { Summary } from '../lib/types';
 
 type Props = {
   loading: boolean;
-  aggregates: Aggregates | null;
+  summary: Summary | null;
 };
 
-export default function StatPanel({ loading, aggregates }: Props) {
+export default function StatPanel({ loading, summary }: Props) {
   return (
     <View style={styles.grid}>
       <View style={styles.row}>
-        <StatCard label="今日の新規" value={aggregates?.todayNew ?? null} loading={loading} />
+        <StatCard label="今日の新規" value={summary?.today_new ?? null} loading={loading} />
         <View style={styles.colGap} />
-        <StatCard label="今日の累計" value={aggregates?.todayTotal ?? null} loading={loading} />
+        <StatCard label="今日の累計" value={summary?.today_total ?? null} loading={loading} />
       </View>
       <View style={styles.rowGap} />
       <View style={styles.row}>
-        <StatCard label="月間累計(MAU)" value={aggregates?.mau ?? null} loading={loading} />
+        <StatCard label="月間累計(MAU)" value={summary?.mau ?? null} loading={loading} />
         <View style={styles.colGap} />
-        <StatCard label="全期間累計" value={aggregates?.allTime ?? null} loading={loading} />
+        <StatCard label="全期間累計" value={summary?.all_time ?? null} loading={loading} />
       </View>
     </View>
   );

--- a/app/daily_user_stats/index.tsx
+++ b/app/daily_user_stats/index.tsx
@@ -1,14 +1,8 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { View, StyleSheet } from 'react-native';
-import { fetchDailyStats } from './lib/api';
-import {
-  computeAggregates,
-  getLast30Days,
-  getLast12Months,
-  type Aggregates,
-  type BarDatum,
-} from './lib/aggregate';
-import type { DailyStat } from './lib/types';
+import { fetchAllStats } from './lib/api';
+import { getLast30Days, formatMonthly, type BarDatum } from './lib/aggregate';
+import type { Summary } from './lib/types';
 import { colors } from './styles/colors';
 import Header from './components/Header';
 import StatPanel from './components/StatPanel';
@@ -16,19 +10,19 @@ import BarChart from './components/BarChart';
 
 export default function DailyUserStatsScreen() {
   const [loading, setLoading] = useState(true);
-  const [aggregates, setAggregates] = useState<Aggregates | null>(null);
+  const [summary, setSummary] = useState<Summary | null>(null);
   const [last30, setLast30] = useState<BarDatum[]>([]);
   const [last12months, setLast12months] = useState<BarDatum[]>([]);
 
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const data: DailyStat[] = await fetchDailyStats();
-      setAggregates(computeAggregates(data));
-      setLast30(getLast30Days(data));
-      setLast12months(getLast12Months(data));
+      const { daily, monthly, summary } = await fetchAllStats();
+      setSummary(summary);
+      setLast30(getLast30Days(daily));
+      setLast12months(formatMonthly(monthly));
     } catch (e) {
-      console.error('Failed to fetch daily stats:', e);
+      console.error('Failed to fetch stats:', e);
     } finally {
       setLoading(false);
     }
@@ -43,7 +37,7 @@ export default function DailyUserStatsScreen() {
       <View style={styles.container}>
         <Header />
         <View style={styles.gap} />
-        <StatPanel loading={loading} aggregates={aggregates} />
+        <StatPanel loading={loading} summary={summary} />
         <View style={styles.gap} />
         <BarChart title="直近30日" data={last30} loading={loading} />
         <View style={styles.gap} />

--- a/app/daily_user_stats/lib/aggregate.ts
+++ b/app/daily_user_stats/lib/aggregate.ts
@@ -1,51 +1,4 @@
-import type { DailyStat } from './types';
-
-function getJapanToday(): string {
-  const now = new Date();
-  // JST = UTC+9
-  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
-  return jst.toISOString().slice(0, 10);
-}
-
-function getJapanMonthStart(): string {
-  return getJapanToday().slice(0, 8) + '01';
-}
-
-// Arithmetic month subtraction — avoids Date timezone issues
-function subtractMonths(ym: string, n: number): string {
-  const [year, month] = ym.split('-').map(Number);
-  let y = year;
-  let m = month - n;
-  while (m <= 0) {
-    m += 12;
-    y -= 1;
-  }
-  return `${y}-${String(m).padStart(2, '0')}`;
-}
-
-export type Aggregates = {
-  todayNew: number;
-  todayTotal: number;
-  mau: number;
-  allTime: number;
-};
-
-export function computeAggregates(data: DailyStat[]): Aggregates {
-  const today = getJapanToday();
-  const monthStart = getJapanMonthStart();
-
-  const todayRow = data.find((r) => r.date === today);
-  const todayNew = todayRow?.new_users ?? 0;
-  const todayTotal = (todayRow?.new_users ?? 0) + (todayRow?.returning_users ?? 0);
-
-  const mau = data
-    .filter((r) => r.date >= monthStart && r.date <= today)
-    .reduce((sum, r) => sum + r.new_users + r.returning_users, 0);
-
-  const allTime = data.reduce((sum, r) => sum + r.new_users + r.returning_users, 0);
-
-  return { todayNew, todayTotal, mau, allTime };
-}
+import type { DailyStat, MonthStat } from './types';
 
 export type BarDatum = {
   label: string;
@@ -62,28 +15,10 @@ export function getLast30Days(data: DailyStat[]): BarDatum[] {
   }));
 }
 
-export function getLast12Months(data: DailyStat[]): BarDatum[] {
-  const today = getJapanToday();
-  const currentYM = today.slice(0, 7);
-
-  const monthMap: Record<string, { new_users: number; returning_users: number }> = {};
-  for (const r of data) {
-    const ym = r.date.slice(0, 7);
-    if (!monthMap[ym]) monthMap[ym] = { new_users: 0, returning_users: 0 };
-    monthMap[ym].new_users += r.new_users;
-    monthMap[ym].returning_users += r.returning_users;
-  }
-
-  const months: BarDatum[] = [];
-  for (let i = 11; i >= 0; i--) {
-    const ym = subtractMonths(currentYM, i);
-    const m = parseInt(ym.slice(5), 10);
-    const entry = monthMap[ym] ?? { new_users: 0, returning_users: 0 };
-    months.push({
-      label: `${m}月`,
-      new_users: entry.new_users,
-      returning_users: entry.returning_users,
-    });
-  }
-  return months;
+export function formatMonthly(data: MonthStat[]): BarDatum[] {
+  return data.map((r) => ({
+    label: `${parseInt(r.month.slice(5), 10)}月`,
+    new_users: r.new_users,
+    returning_users: r.returning_users,
+  }));
 }

--- a/app/daily_user_stats/lib/api.ts
+++ b/app/daily_user_stats/lib/api.ts
@@ -1,16 +1,38 @@
-import type { DailyStat } from './types';
+import type { DailyStat, MonthStat, Summary } from './types';
 
-const ENDPOINT =
-  'https://script.google.com/macros/s/AKfycbz0RvIKLuuRBCktb8m7RKGk0dD0mzo6DhYFt_32zIMnqWnsLzypvZ99OZY95wQTVtW1/exec?endpoint=daily_user_stats';
+const BASE =
+  'https://script.google.com/macros/s/AKfycbz0RvIKLuuRBCktb8m7RKGk0dD0mzo6DhYFt_32zIMnqWnsLzypvZ99OZY95wQTVtW1/exec';
 
-export async function fetchDailyStats(): Promise<DailyStat[]> {
-  const res = await fetch(ENDPOINT);
+async function get<T>(endpoint: string): Promise<T> {
+  const res = await fetch(`${BASE}?endpoint=${endpoint}`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const raw = await res.json();
-  return (raw as unknown[]).filter(
-    (r): r is DailyStat =>
-      typeof (r as DailyStat).date === 'string' &&
-      typeof (r as DailyStat).new_users === 'number' &&
-      typeof (r as DailyStat).returning_users === 'number'
-  );
+  return res.json() as Promise<T>;
+}
+
+export async function fetchAllStats(): Promise<{
+  daily: DailyStat[];
+  monthly: MonthStat[];
+  summary: Summary;
+}> {
+  const [daily, monthly, summary] = await Promise.all([
+    get<unknown[]>('daily_30d'),
+    get<unknown[]>('monthly_12m'),
+    get<Record<string, unknown>>('summary'),
+  ]);
+
+  return {
+    daily: (daily as unknown[]).filter(
+      (r): r is DailyStat =>
+        typeof (r as DailyStat).date === 'string' &&
+        typeof (r as DailyStat).new_users === 'number' &&
+        typeof (r as DailyStat).returning_users === 'number'
+    ),
+    monthly: (monthly as unknown[]).filter(
+      (r): r is MonthStat =>
+        typeof (r as MonthStat).month === 'string' &&
+        typeof (r as MonthStat).new_users === 'number' &&
+        typeof (r as MonthStat).returning_users === 'number'
+    ),
+    summary: summary as Summary,
+  };
 }

--- a/app/daily_user_stats/lib/types.ts
+++ b/app/daily_user_stats/lib/types.ts
@@ -3,3 +3,16 @@ export type DailyStat = {
   new_users: number;
   returning_users: number;
 };
+
+export type MonthStat = {
+  month: string; // YYYY-MM
+  new_users: number;
+  returning_users: number;
+};
+
+export type Summary = {
+  today_new: number;
+  today_total: number;
+  mau: number;
+  all_time: number;
+};


### PR DESCRIPTION
日別データをクライアントでSUMして月別/MAUを算出していたが、
同一ユーザーが複数日来訪するとその分だけ重複カウントされる問題があった。

バックエンドを daily_30d / monthly_12m / summary の3エンドポイントに分割。 フロントは Promise.all で並列フェッチし、サーバー側の重複排除済み値を直接利用。
クライアント側の月別集計ロジック(getLast12Months / computeAggregates)は撤廃。

- lib/types.ts: MonthStat / Summary 型を追加
- lib/api.ts: fetchAllStats() (3並列フェッチ) に一本化
- lib/aggregate.ts: formatMonthly() 追加、クライアント集計ロジック削除
- components/StatPanel.tsx: Aggregates → Summary 型に付け替え
- index.tsx: 新API・新型を使うよう配線し直し